### PR TITLE
Kagre preserve working path on impersonate

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -3,5 +3,5 @@
 . InvokeBuildHelperTasks
 
 # Build configuration
-$IBHConfig.RepositoryTask.Token = Use-VaultSecureString -TargetName 'GitHub Token (claudiospizzi)'
-$IBHConfig.GalleryTask.Token    = Use-VaultSecureString -TargetName 'PowerShell Gallery Key (claudiospizzi)'
+$IBHConfig.RepositoryTask.Token = Use-VaultSecureString -TargetName 'GitHub Token (claudiospizzi)' -NonInteractive
+$IBHConfig.GalleryTask.Token    = Use-VaultSecureString -TargetName 'PowerShell Gallery Key (claudiospizzi)' -NonInteractive

--- a/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
@@ -46,5 +46,7 @@ function Pop-ImpersonationContext
         {
             Set-PSReadlineOption -HistorySaveStyle $Script:PSReadlineHistorySaveStyle -ErrorAction SilentlyContinue
         }
+        
+        popd;popd;
     }
 }

--- a/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
@@ -35,6 +35,9 @@ function Pop-ImpersonationContext
         # Get the latest impersonation context
         $popImpersonationContext = $Script:ImpersonationContext.Pop()
 
+        # Don't assume that the working path is still accessable
+        Set-Location $env:SystemDrive\
+        
         # Undo the impersonation
         $popImpersonationContext.Undo()
 

--- a/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
@@ -36,7 +36,7 @@ function Pop-ImpersonationContext
         $popImpersonationContext = $Script:ImpersonationContext.Pop()
 
         # Don't assume that the working path is still accessable
-        Set-Location $env:SystemDrive\
+        Push-Location $env:SystemDrive\
         
         # Undo the impersonation
         $popImpersonationContext.Undo()

--- a/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
@@ -35,8 +35,8 @@ function Pop-ImpersonationContext
         # Get the latest impersonation context
         $popImpersonationContext = $Script:ImpersonationContext.Pop()
 
-        # Don't assume that the working path is still accessable
-        Set-Location $env:SystemDrive\
+        # Go to the system root drive, to prevent access denied on user paths
+        Set-Location -Path "$env:SystemDrive\"
         
         # Undo the impersonation
         $popImpersonationContext.Undo()
@@ -47,6 +47,7 @@ function Pop-ImpersonationContext
             Set-PSReadlineOption -HistorySaveStyle $Script:PSReadlineHistorySaveStyle -ErrorAction SilentlyContinue
         }
         
-        popd -StackName 'ImpersonateStack'
+        # Reset the working path
+        Pop-Location -StackName 'ImpersonateStack'
     }
 }

--- a/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Pop-ImpersonationContext.ps1
@@ -36,7 +36,7 @@ function Pop-ImpersonationContext
         $popImpersonationContext = $Script:ImpersonationContext.Pop()
 
         # Don't assume that the working path is still accessable
-        Push-Location $env:SystemDrive\
+        Set-Location $env:SystemDrive\
         
         # Undo the impersonation
         $popImpersonationContext.Undo()
@@ -47,6 +47,6 @@ function Pop-ImpersonationContext
             Set-PSReadlineOption -HistorySaveStyle $Script:PSReadlineHistorySaveStyle -ErrorAction SilentlyContinue
         }
         
-        popd;popd;
+        popd -StackName 'ImpersonateStack'
     }
 }

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -10,7 +10,7 @@
         impersonated in the current session.
 
     .INPUTS
-        None.
+        ToDo
 
     .OUTPUTS
         None.

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -10,7 +10,7 @@
         impersonated in the current session.
 
     .INPUTS
-        ToDo
+        None.
 
     .OUTPUTS
         None.

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -86,17 +86,9 @@ function Push-ImpersonationContext
     # Finally, close the handle to the token
     [Win32.Kernel32]::CloseHandle($tokenHandle) | Out-Null
     
-    try
+    if(Test-Path $OldPath -ErrorAction SilentlyContinue)
     {
-        $eap,$ErrorActionPreference = $ErrorActionPreference,'Stop';
-        Get-ChildItem -Path $OldPath | Out-Null #throws UnauthorizedAccessException
         Pop-Location  -StackName 'ImpersonateStack'
         Push-Location -StackName 'ImpersonateStack'
-    }
-    catch{}
-    finally
-    {
-        $ErrorActionPreference=$eap
-        Remove-Variable -Name 'eap'
     }
 }

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -86,7 +86,7 @@ function Push-ImpersonationContext
     # Finally, close the handle to the token
     [Win32.Kernel32]::CloseHandle($tokenHandle) | Out-Null
     
-    if(Test-Path $OldPath -ErrorAction SilentlyContinue)
+    if(Test-Path $OldPath)
     {
         Pop-Location  -StackName 'ImpersonateStack'
         Push-Location -StackName 'ImpersonateStack'

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -76,7 +76,7 @@ function Push-ImpersonationContext
     }
 
     # Go to the system root drive, to prevent access denied on user paths
-    $OldPath = get-location
+    $OldPath = Get-Location
     Push-Location -Path "$Env:SystemDrive\" -StackName 'ImpersonateStack'
 
     # Now, impersonate the new user account
@@ -86,13 +86,17 @@ function Push-ImpersonationContext
     # Finally, close the handle to the token
     [Win32.Kernel32]::CloseHandle($tokenHandle) | Out-Null
     
-   try{
-      $eap,$ErrorActionPreference = $ErrorActionPreference,'Stop';
-      $null = ls $OldPath #throws UnauthorizedAccessException
-      popd  -StackName 'ImpersonateStack'
-      pushd -StackName 'ImpersonateStack'
-   }catch{}finally{
-      $ErrorActionPreference=$eap
-      rv eap
-   }
+    try
+    {
+        $eap,$ErrorActionPreference = $ErrorActionPreference,'Stop';
+        Get-ChildItem -Path $OldPath | Out-Null #throws UnauthorizedAccessException
+        Push-Location -StackName 'ImpersonateStack'
+        Pop-Location  -StackName 'ImpersonateStack'
+    }
+    catch{}
+    finally
+    {
+        $ErrorActionPreference=$eap
+        Remove-Variable -Name 'eap'
+    }
 }

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -77,7 +77,7 @@ function Push-ImpersonationContext
 
     # Go to the system root drive, to prevent access denied on user paths
     $OldPath = get-location
-    Push-Location -Path "$Env:SystemDrive\" #ToDo: code $script:directory_stack, don't rely on user to preserve the pushd stack
+    Push-Location -Path "$Env:SystemDrive\" -StackName 'ImpersonateStack'
 
     # Now, impersonate the new user account
     $newImpersonationContext = [System.Security.Principal.WindowsIdentity]::Impersonate($tokenHandle)
@@ -89,7 +89,8 @@ function Push-ImpersonationContext
    try{
       $eap,$ErrorActionPreference = $ErrorActionPreference,'Stop';
       $null = ls $OldPath #throws UnauthorizedAccessException
-      popd;pushd
+      popd  -StackName 'ImpersonateStack'
+      pushd -StackName 'ImpersonateStack'
    }catch{}finally{
       $ErrorActionPreference=$eap
       rv eap

--- a/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
+++ b/SecurityFever/Functions/Impersonation/Push-ImpersonationContext.ps1
@@ -90,8 +90,8 @@ function Push-ImpersonationContext
     {
         $eap,$ErrorActionPreference = $ErrorActionPreference,'Stop';
         Get-ChildItem -Path $OldPath | Out-Null #throws UnauthorizedAccessException
-        Push-Location -StackName 'ImpersonateStack'
         Pop-Location  -StackName 'ImpersonateStack'
+        Push-Location -StackName 'ImpersonateStack'
     }
     catch{}
     finally

--- a/SecurityFever/Functions/Vault/Use-VaultSecureString.ps1
+++ b/SecurityFever/Functions/Vault/Use-VaultSecureString.ps1
@@ -42,7 +42,7 @@ function Use-VaultSecureString
         # The vault secure string entry name.
         [Parameter(Mandatory = $true)]
         [System.String]
-        $TargetName
+        $TargetName,
         
         # Used to explicitly set NonInteractive mode
         [Parameter(Mandatory = $false)]

--- a/SecurityFever/Functions/Vault/Use-VaultSecureString.ps1
+++ b/SecurityFever/Functions/Vault/Use-VaultSecureString.ps1
@@ -43,11 +43,16 @@ function Use-VaultSecureString
         [Parameter(Mandatory = $true)]
         [System.String]
         $TargetName
+        
+        # Used to explicitly set NonInteractive mode
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $NonInteractive
     )
 
     # Only run Read-Host if the PowerShell process is in interactive mode. If
     # this is not the case, just return $null indicating
-    $isInteractive = [Environment]::UserInteractive -and [Environment]::GetCommandLineArgs().Where({ $_ -like '-NonI*' }).Count -eq 0
+    $isInteractive = !$NonInteractive -and [Environment]::UserInteractive -and [Environment]::GetCommandLineArgs().Where({ $_ -like '-NonI*' }).Count -eq 0
 
     # Get all entries matching the parameters.
     $entries = @(Get-VaultEntry @PSBoundParameters)


### PR DESCRIPTION
Take a look, this is a breaking change, but hopefully for the better.

The idea here was to remain in the current on the same working path as long as the new context still had access to it.

Also, if you don't add it in; please at least fix the assumption that when you pop the context back from admin the original user has access to wherever admin wandered off to...